### PR TITLE
encoding unicode to ascii in warn_import_error

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -1260,6 +1260,9 @@ def _setup(module, extras):
     Qt.__binding__ = module.__name__
 
     def _warn_import_error(exc, module):
+        if sys.version_info < (3, 0):
+            if isinstance(exc, unicode):
+                exc = exc.encode('ascii', 'replace')
         msg = str(exc)
         if "No module named" in msg:
             return


### PR DESCRIPTION
Encoding unicode to ascii with replace if Python 2 before casting it to string to avoid UnicodeDecodeError